### PR TITLE
Replace Xchat to Hexchat

### DIFF
--- a/manual/index.html
+++ b/manual/index.html
@@ -40,16 +40,16 @@
 	<li><strong>윈도:</strong><ul>
 		<li><del><a href="mirc">mIRC</a></del></li>
 		<li><del><a href="chatzilla">Chatzilla</a></del></li>
-		<li><del><a href="xchat-win32">X-Chat</a></del></li>
+		<li><del><a href="hexchat-win32">HexChat</a></del></li>
 		<li>...</li>
 	</ul></li>
 	<li><strong>맥 오에스 텐:</strong><ul>
 		<li><del><a href="colloquy">Colloquy</a></del></li>
-		<li><del><a href="xchat-aqua">X-Chat Aqua</a></del></li>
+		<li><del><a href="hexchat-aqua">HexChat</a></del></li>
 		<li><del><a href="limechat">LimeChat</a></del></li>
 	</ul></li>
 	<li><strong>리눅스 및 유닉스:</strong><ul>
-		<li><del><a href="xchat">X-Chat</a></del></li>
+		<li><del><a href="hexchat">HexChat</a></del></li>
 		<li><del><a href="konversation">Konversation</a></del></li>
 		<li><del><a href="irssi">irssi</a></del></li>
 		<li>...</li>


### PR DESCRIPTION
Replaced Xchat to Hexchat on faq.html on 5cd9b084c24d375ba5a95a676521b3b2960eaa1e, so why not on manual/index.html?